### PR TITLE
Added feature setTimeout() for curl client.

### DIFF
--- a/src/CURLClient.php
+++ b/src/CURLClient.php
@@ -7,7 +7,8 @@
  */
 namespace Sonrisa\Component\RestfulClient;
 
-use Sonrisa\Component\RestfulClient\Interfaces\ClientInterface as ClientInterface;
+use Sonrisa\Component\RestfulClient\Exceptions\RestfulClientException;
+use Sonrisa\Component\RestfulClient\Interfaces\ClientInterface;
 
 class CURLClient extends AbstractClient implements ClientInterface
 {
@@ -33,6 +34,16 @@ class CURLClient extends AbstractClient implements ClientInterface
         curl_setopt($this->curl, CURLOPT_HEADER, true);
         curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);   // return transfer instead of outputting .
         curl_setopt($this->curl, CURLINFO_HEADER_OUT, true);
+    }
+
+    /**
+     * Set timeout for request.
+     * @return ClientInterface
+     */
+    public function setTimeout($timeout)
+    {
+        curl_setopt($this->curl, CURLOPT_TIMEOUT, $timeout);
+        return $this;
     }
 
     /**
@@ -100,6 +111,13 @@ class CURLClient extends AbstractClient implements ClientInterface
 
             //Send request and retrieve the response.
             $data = curl_exec($this->curl);
+
+            // Turn any kind of curl errors into exceptions
+            if (curl_errno($this->curl)) {
+                throw new RestfulClientException(sprintf('curl error %s: "%s"',
+                    curl_errno($this->curl), curl_error($this->curl)));
+            }
+
             $data = explode("\r\n", $data);
 
             //Reads the response HTTP header and returns its contents in an array.

--- a/src/FileGetContentsClient.php
+++ b/src/FileGetContentsClient.php
@@ -7,10 +7,23 @@
  */
 namespace Sonrisa\Component\RestfulClient;
 
-use Sonrisa\Component\RestfulClient\Interfaces\ClientInterface as ClientInterface;
+
+use Sonrisa\Component\RestfulClient\Interfaces\ClientInterface;
 
 class FileGetContentsClient extends AbstractClient implements ClientInterface
 {
+
+    /**
+     * Set timeout for request.
+     * @return ClientInterface
+     */
+    public function setTimeout($timeout)
+    {
+        // TODO: Implement, maybe we should throw an exception like this?
+        // throw new RestfulClientException('Sorry, setTimeout() is currently only implemented for curl but not for stream context based clients!');
+        return $this;
+    }
+
     /**
      * @param  string                            $methodName
      * @param  string                            $url

--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -17,4 +17,10 @@ interface ClientInterface
      * @return mixed
      */
     public function request($methodName, $url, array $params=array(), array $headers=array());
+
+    /**
+     * @param int $timeout
+     * @return RestfulClientInterface
+     */
+    public function setTimeout($timeout);
 }

--- a/src/Interfaces/RestfulClientInterface.php
+++ b/src/Interfaces/RestfulClientInterface.php
@@ -10,6 +10,12 @@ namespace Sonrisa\Component\RestfulClient\Interfaces;
 interface RestfulClientInterface
 {
     /**
+     * @param int $timeout
+     * @return mixed
+     * @return \Sonrisa\Component\RestfulClient\Interfaces\RestfulClientInterface
+     */
+    public function setTimeout($timeout);
+    /**
      * @param $field
      * @param $value
      * @return \Sonrisa\Component\RestfulClient\Interfaces\RestfulClientInterface

--- a/src/RestfulClient.php
+++ b/src/RestfulClient.php
@@ -180,6 +180,19 @@ class RestfulClient implements RestfulClientInterface
     }
 
     /**
+     * (Optional) Set the timeout value for requests.
+     *
+     * @param int $timeout
+     * @return RestfulClient
+     */
+    public function setTimeout($timeout)
+    {
+        $this->client->setTimeout($timeout);
+
+        return $this;
+    }
+
+    /**
      * Allows sending a request to the specified URL using HTTP's GET method.
      *
      * @param  string $url


### PR DESCRIPTION
Hi Nil,

some while ago, I implemented this (in my eyes useful) little feature I deadly needed in my environment. But I waited with sending a pull request and stuck with my feature-branch since then because I implemented the timeout feature only for the CURL based implementation so far. 

I'm not sure... The file_get_contents implementation needs to be overhauled anyway, so what do you think? Merging anyway and making things new with the next major release?

Greetings from Germany to Spain!
Matthias
