### PR TITLE
Feature curl setopt

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Add the following to your `composer.json` file :
 - $this->head($url,array $params=array());
 - $this->other($methodName,$url,array $params=array());
 
+CURL client only methods:
+
+- $this->setTimeout($timeout);
+- $this->setCurlOpt($name,$value);
+
+
 <a name="block3"></a>
 ## 3. Usage
 Usage is really straight-forward. Example provided below.

--- a/src/CURLClient.php
+++ b/src/CURLClient.php
@@ -37,6 +37,16 @@ class CURLClient extends AbstractClient implements ClientInterface
     }
 
     /**
+     * Set any arbitrary CURL option via curl_setopt.
+     * @param $curlOptName
+     * @param $curlOptValue
+     */
+    public function setOpt($curlOptName, $curlOptValue)
+    {
+        return curl_setopt($this->curl, $curlOptName, $curlOptValue);
+    }
+
+    /**
      * Set timeout for request.
      * @return ClientInterface
      */

--- a/src/RestfulClient.php
+++ b/src/RestfulClient.php
@@ -202,6 +202,8 @@ class RestfulClient implements RestfulClientInterface
         if ($this->client instanceof CURLClient) {
             $this->client->setOpt($curlOptName, $curlOptValue);
         }
+        
+        return $this;
     }
 
     /**

--- a/src/RestfulClient.php
+++ b/src/RestfulClient.php
@@ -193,6 +193,18 @@ class RestfulClient implements RestfulClientInterface
     }
 
     /**
+     * Set any arbitrary CURL option via curl_setopt (applies for CURL clients only).
+     * @param $curlOptName
+     * @param $curlOptValue
+     */
+    public function setCurlOpt($curlOptName, $curlOptValue)
+    {
+        if ($this->client instanceof CURLClient) {
+            $this->client->setOpt($curlOptName, $curlOptValue);
+        }
+    }
+
+    /**
      * Allows sending a request to the specified URL using HTTP's GET method.
      *
      * @param  string $url


### PR DESCRIPTION
Nil,

me again. This time I actually had some trouble with about 80.000 temporary files created "silently" within /tmp. :-(

Therefore and because I had need in another case to directly control one curl options I introduced the method setCurlOpt() for curl clients.

I'd suggest this pull request and the next one (I'll send in a minute) to be combined as at least v 1.3. If we want to be absolutely correct in semantic versioning terms it should be 2.0. But up on you!

Hope you're well - strange times all over Europe again...
Matthias
