### PR TITLE
Bc disable cookiejar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Restful Client Component - CHANGELOG
+
+## v 1.3
+
+- Change: Removed implicit definition of option `CURLOPT_COOKIEJAR` creating a temporary file on each single
+request. **Attention: This is a non-BC change and therefore may break your code in rare cases**, 
+i.e. only if you somehow make use of the cookie data collected in files written to /tmp/CURLCOOKIE[tmp-name]. 
+Please note that using the option `CURLOPT_COOKIEJAR` for itself just dumps received cookie data and doesn't 
+*send* any, so it seemed reasonable to make this change in favor of not getting a polluted /tmp directory.
+It is very easy though to re-activate the original behavior by using the new method `setCurlOpt`:
+
+```
+    $restfulClient = new RestfulClient();
+    $restfulClient->setCurlOpt(CURLOPT_COOKIEJAR, tempnam("/tmp", "CURLCOOKIE"));
+```
+
+
+- Feature: Added method `setCurlOpt($name, $value)` allowing the definition of arbitrary curl options 
+(curl clients only).
+
+## v 1.2
+
+- Feature: Added method `setTimeout($timeout)` (curl clients only).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Add the following to your `composer.json` file :
 - $this->head($url,array $params=array());
 - $this->other($methodName,$url,array $params=array());
 
+CURL client only methods:
+
+- $this->setTimeout($timeout);
+- $this->setCurlOpt($name,$value);
+
+
 <a name="block3"></a>
 ## 3. Usage
 Usage is really straight-forward. Example provided below.

--- a/src/CURLClient.php
+++ b/src/CURLClient.php
@@ -37,6 +37,16 @@ class CURLClient extends AbstractClient implements ClientInterface
     }
 
     /**
+     * Set any arbitrary CURL option via curl_setopt.
+     * @param $curlOptName
+     * @param $curlOptValue
+     */
+    public function setOpt($curlOptName, $curlOptValue)
+    {
+        return curl_setopt($this->curl, $curlOptName, $curlOptValue);
+    }
+
+    /**
      * Set timeout for request.
      * @return ClientInterface
      */

--- a/src/CURLClient.php
+++ b/src/CURLClient.php
@@ -22,8 +22,6 @@ class CURLClient extends AbstractClient implements ClientInterface
         //Set CURL basic fields.
         $this->curl = curl_init();
 
-        $cookie = tempnam("/tmp", "CURLCOOKIE");
-        curl_setopt($this->curl, CURLOPT_COOKIEJAR, $cookie);    //Allows cookies.
         curl_setopt($this->curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         curl_setopt($this->curl, CURLOPT_FOLLOWLOCATION, true);
 

--- a/src/RestfulClient.php
+++ b/src/RestfulClient.php
@@ -202,6 +202,8 @@ class RestfulClient implements RestfulClientInterface
         if ($this->client instanceof CURLClient) {
             $this->client->setOpt($curlOptName, $curlOptValue);
         }
+        
+        return $this;
     }
 
     /**

--- a/src/RestfulClient.php
+++ b/src/RestfulClient.php
@@ -193,6 +193,18 @@ class RestfulClient implements RestfulClientInterface
     }
 
     /**
+     * Set any arbitrary CURL option via curl_setopt (applies for CURL clients only).
+     * @param $curlOptName
+     * @param $curlOptValue
+     */
+    public function setCurlOpt($curlOptName, $curlOptValue)
+    {
+        if ($this->client instanceof CURLClient) {
+            $this->client->setOpt($curlOptName, $curlOptValue);
+        }
+    }
+
+    /**
      * Allows sending a request to the specified URL using HTTP's GET method.
      *
      * @param  string $url


### PR DESCRIPTION
And here's the second one. I also introduced a CHANGELOG - so, instead of describing again what I've already written, I just copy it over here:

- Change: Removed implicit definition of option `CURLOPT_COOKIEJAR` creating a temporary file on each single request. **Attention: This is a non-BC change and therefore may break your code in rare cases**, i.e. only if you somehow make use of the cookie data collected in files written to /tmp/CURLCOOKIE[tmp-name]. Please note that using the option `CURLOPT_COOKIEJAR` for itself just dumps received cookie data and doesn't *send* any, so it seemed reasonable to make this change in favor of not getting a polluted /tmp directory. It is very easy though to re-activate the original behavior by using the new method `setCurlOpt`:

```
    $restfulClient = new RestfulClient();
    $restfulClient->setCurlOpt(CURLOPT_COOKIEJAR, tempnam("/tmp", "CURLCOOKIE"));
```

Rock on,
Matthias
